### PR TITLE
Fixed deployment integration for Symfony 4.2

### DIFF
--- a/.deploy/deploy_playbook.yaml
+++ b/.deploy/deploy_playbook.yaml
@@ -10,7 +10,7 @@
           deploy_path: "/home/{{ ansible_user_id }}"
           archive_path: ../project.tar.gz
           linked_files: # <-- Common place to add your files, that should be reused between deployments
-              - .env
+              - .env.local
           linked_directories: # <-- Common place to add your files, that should be reused between deployments
               - var/log
 


### PR DESCRIPTION
Ansible deployment will fail for Syfmony 4.2 applications,
because since 4.2 Symfony is using .env.local instead of .env for specific environment.

:information_source: Merging from upstream: https://github.com/nfqakademija/kickstart/pull/48